### PR TITLE
perf: scan all Skills concurrently with a bounded worker pool

### DIFF
--- a/electron/security-scanner-service.test.ts
+++ b/electron/security-scanner-service.test.ts
@@ -1430,3 +1430,141 @@ test("projects binary, size, depth and unreadable-directory limits as stable rea
   if (process.platform !== "win32")
     assert.equal(codes.has("unavailable"), true);
 });
+
+async function addDiscoveredSkill(
+  home: string,
+  skillsDirRelativeToHome: string,
+  dirName: string,
+): Promise<void> {
+  const dir = join(home, skillsDirRelativeToHome, dirName);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, "SKILL.md"), `# ${dirName}\n`, "utf8");
+}
+
+/** Scanner seam whose every call blocks until released; tracks concurrency. */
+function createGatedScanner() {
+  let active = 0;
+  let maxActive = 0;
+  let totalCalls = 0;
+  const waiters: Array<() => void> = [];
+  const waitForCallCount = async (count: number): Promise<void> => {
+    for (let index = 0; index < 200; index += 1) {
+      if (totalCalls >= count) return;
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    throw new Error(`scanner call count never reached ${count}`);
+  };
+  return {
+    scanner: (async () => {
+      totalCalls += 1;
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise<void>((resolve) => {
+        waiters.push(resolve);
+      });
+      active -= 1;
+      return report();
+    }) as never,
+    active: (): number => active,
+    maxActive: (): number => maxActive,
+    totalCalls: (): number => totalCalls,
+    waitForCallCount,
+    /** Release every blocked call in reverse arrival order (worst-case commit order). */
+    releaseAll: (): void => {
+      for (let index = waiters.length - 1; index >= 0; index -= 1)
+        waiters[index]!();
+      waiters.length = 0;
+    },
+  };
+}
+
+test("scans all Skills concurrently through a bounded pool with deterministic ordering", async () => {
+  const { home } = await fixture();
+  for (const name of ["alpha", "beta", "gamma", "delta"])
+    await addDiscoveredSkill(home, ".codex/skills", name);
+  const gated = createGatedScanner();
+  const service = new SecurityScannerService({
+    homeDirectory: home,
+    locale: () => "zh-CN",
+    env: {},
+    secretStorage: unavailableStorage,
+    scanConcurrency: 2,
+    scanner: gated.scanner,
+  });
+  const targets = await service.listSkills();
+  assert.equal(targets.length, 5);
+
+  const state = await service.start({ scope: "all", mode: "quick" });
+  assert.equal(state.status, "running");
+  // First pool round: two workers scan two Skills at once and block.
+  await gated.waitForCallCount(2);
+  assert.equal(gated.active(), 2);
+  assert.equal(gated.maxActive(), 2);
+  gated.releaseAll();
+  // Second round takes the next two targets; concurrency stays bounded.
+  await gated.waitForCallCount(4);
+  assert.equal(gated.active(), 2);
+  assert.equal(gated.maxActive(), 2);
+  gated.releaseAll();
+  // Third round has a single remaining target.
+  await gated.waitForCallCount(5);
+  gated.releaseAll();
+  await waitForTerminal(service);
+  assert.equal(gated.maxActive(), 2);
+
+  const status = service.getStatus();
+  assert.equal(status.status, "complete");
+  assert.equal(status.progress.completed, 5);
+  assert.equal(status.progress.failed, 0);
+  assert.equal(status.progress.skipped, 0);
+  // History is newest-first; entries commit in discovery order regardless of
+  // the completion race the gated scanner produced.
+  const history = await service.history();
+  assert.deepEqual(
+    history.map((entry) => entry.skillName),
+    [...targets].map((target) => target.name).reverse(),
+  );
+  assert.deepEqual(
+    status.resultIds,
+    [...history].reverse().map((entry) => entry.id),
+  );
+});
+
+test("cancellation stops the pool between Skills and counts the rest as skipped", async () => {
+  const { home } = await fixture();
+  await addDiscoveredSkill(home, ".codex/skills", "extra-one");
+  await addDiscoveredSkill(home, ".codex/skills", "extra-two");
+  const gated = createGatedScanner();
+  const service = new SecurityScannerService({
+    homeDirectory: home,
+    locale: () => "zh-CN",
+    env: {},
+    secretStorage: unavailableStorage,
+    scanConcurrency: 2,
+    scanner: gated.scanner,
+  });
+  const targets = await service.listSkills();
+  assert.equal(targets.length, 3);
+
+  await service.start({ scope: "all", mode: "quick" });
+  await gated.waitForCallCount(2);
+  assert.deepEqual(service.cancel(), { cancelled: true });
+  // In-flight Skills finish; the worker pool never starts the remaining one.
+  gated.releaseAll();
+  await waitForTerminal(service);
+
+  const status = service.getStatus();
+  assert.equal(status.status, "cancelled");
+  assert.equal(status.progress.completed, 2);
+  assert.equal(status.progress.failed, 0);
+  assert.equal(status.progress.skipped, 1);
+  const history = await service.history();
+  assert.deepEqual(
+    history.map((entry) => entry.skillName),
+    [targets[1]?.name, targets[0]?.name],
+  );
+  assert.deepEqual(
+    status.resultIds,
+    [...history].reverse().map((entry) => entry.id),
+  );
+});

--- a/electron/security-scanner-service.ts
+++ b/electron/security-scanner-service.ts
@@ -39,6 +39,10 @@ const MAX_FILE_BYTES = 1_000_000;
 const MAX_TOTAL_BYTES = 20_000_000;
 const MAX_HISTORY = 200;
 const HISTORY_VERSION = 1;
+/** Default width of the per-run Skill scan worker pool (see `scanConcurrency`). */
+const DEFAULT_SCAN_CONCURRENCY = 4;
+/** Upper clamp for `scanConcurrency`; the pool never starts more workers than targets. */
+const MAX_SCAN_CONCURRENCY = 16;
 
 interface SkillFile {
   path: string;
@@ -189,6 +193,15 @@ export interface SecurityScannerServiceOptions {
   ) => void | Promise<void>;
   /** Deterministic TOCTOU test hook; production never supplies it. */
   readonly beforeOpenFile?: (path: string) => Promise<void>;
+  /**
+   * Width of the bounded worker pool that scans discovered Skill targets
+   * concurrently inside one run (default 4, clamped to 1..16). A full-model
+   * scan issues several sequential LLM requests per Skill, so an all-skills
+   * run is network-bound and parallel targets divide its wall-clock time by
+   * roughly the pool width. Keep the value modest to respect provider rate
+   * limits; cancellation semantics stay unchanged ("between skills").
+   */
+  readonly scanConcurrency?: number;
 }
 
 export interface SecurityScannerPersistence {
@@ -651,6 +664,7 @@ function cloneState(state: SecurityScanState): SecurityScanState {
 
 export class SecurityScannerService {
   readonly #options: SecurityScannerServiceOptions;
+  readonly #scanConcurrency: number;
   readonly #persistence: SecurityScannerPersistence;
   readonly #trusted = new Map<string, TrustedSkill>();
   #state = emptyState();
@@ -673,6 +687,10 @@ export class SecurityScannerService {
     if (!persistence)
       throw new Error("SQLite security scanner persistence is required");
     this.#persistence = persistence;
+    this.#scanConcurrency = Math.min(
+      MAX_SCAN_CONCURRENCY,
+      Math.max(1, options.scanConcurrency ?? DEFAULT_SCAN_CONCURRENCY),
+    );
   }
 
   getRuntimeCapability(): SecurityRuntimeCapability {
@@ -1089,31 +1107,88 @@ export class SecurityScannerService {
       lastFinishedAt.set(entry.skillRef, timestamp);
       lastContentHash.set(entry.skillRef, entry.report.contentHash);
     }
-    for (const target of targets) {
-      if (!this.#isActive(id, epoch)) return;
-      if (this.#cancelRequested) {
-        this.#state.progress.skipped +=
-          targets.length - this.#state.progress.started;
-        break;
-      }
-      const trusted = this.#trusted.get(target.skillRef);
-      if (!trusted) continue;
-      const itemStartedAt = this.#now();
-      this.#state.progress.started += 1;
-      this.#state.currentSkill = {
-        skillRef: target.skillRef,
-        name: target.name,
-      };
-      try {
-        const collected = await this.#collect(trusted.root);
+    // Bounded worker pool: a full-model scan of one Skill issues several
+    // sequential LLM requests, so an all-skills run is network-bound. Scanning
+    // up to `scanConcurrency` targets in parallel divides wall-clock time by
+    // roughly the pool width while leaving observable ordering intact: each
+    // worker finishes its current Skill before picking another (cancellation
+    // stays "between skills") and completed entries are committed in discovery
+    // order below, independent of completion races.
+    const results: Array<{ index: number; entry: SecurityScanHistoryEntry }> =
+      [];
+    let cursor = 0;
+    const workerCount = Math.min(this.#scanConcurrency, targets.length);
+    const runWorker = async (): Promise<void> => {
+      for (;;) {
         if (!this.#isActive(id, epoch)) return;
-        // Unchanged since the last complete automatic scan: skip re-analysis to
-        // avoid wasting model tokens/time (manual runs always re-scan).
-        if (
-          request.trigger === "automatic" &&
-          lastContentHash.get(target.skillRef) ===
-            contentHashOf(collected.files)
-        ) {
+        if (this.#cancelRequested) return;
+        const index = cursor;
+        cursor += 1;
+        if (index >= targets.length) return;
+        const target = targets[index];
+        const trusted = this.#trusted.get(target.skillRef);
+        if (!trusted) continue;
+        const itemStartedAt = this.#now();
+        this.#state.progress.started += 1;
+        this.#state.currentSkill = {
+          skillRef: target.skillRef,
+          name: target.name,
+        };
+        try {
+          const collected = await this.#collect(trusted.root);
+          if (!this.#isActive(id, epoch)) return;
+          // Unchanged since the last complete automatic scan: skip re-analysis to
+          // avoid wasting model tokens/time (manual runs always re-scan).
+          if (
+            request.trigger === "automatic" &&
+            lastContentHash.get(target.skillRef) ===
+              contentHashOf(collected.files)
+          ) {
+            const entry: SecurityScanHistoryEntry = {
+              id: `${id}:${target.skillRef.slice("skill:".length, "skill:".length + 16)}`,
+              scanId: id,
+              skillRef: target.skillRef,
+              skillName: target.name,
+              mode: request.mode,
+              trigger: request.trigger,
+              locale,
+              status: "skipped",
+              startedAt: itemStartedAt,
+              finishedAt: this.#now(),
+              errorCode: "security.scan.unchanged",
+            };
+            results.push({ index, entry });
+            this.#state.progress.skipped += 1;
+            continue;
+          }
+          const scanRequest = {
+            mode: request.mode,
+            locale,
+            files: collected.files,
+            ...(config == null ? {} : { model: config }),
+          };
+          const scanner = this.#options.scanner ?? scanSkill;
+          const report = await scanner(scanRequest, {
+            fetch: createSecurityScannerFetch(),
+          });
+          if (!this.#isActive(id, epoch)) return;
+          const dto = sanitizeReport(
+            report,
+            config?.apiKey ? [config.apiKey] : [],
+          );
+          if (collected.hostSkipped.length > 0) {
+            dto.status = "partial";
+            const hostPaths = new Set(
+              collected.hostSkipped.map((item) => item.path),
+            );
+            dto.skippedFiles = [
+              ...dto.skippedFiles.filter((item) => !hostPaths.has(item.path)),
+              ...collected.hostSkipped,
+            ];
+            if (dto.findings.length === 0) dto.verdict = "unknown";
+          }
+          finalizeTerminalPartialReport(dto);
+          const status = dto.status;
           const entry: SecurityScanHistoryEntry = {
             id: `${id}:${target.skillRef.slice("skill:".length, "skill:".length + 16)}`,
             scanId: id,
@@ -1122,84 +1197,56 @@ export class SecurityScannerService {
             mode: request.mode,
             trigger: request.trigger,
             locale,
-            status: "skipped",
+            status,
             startedAt: itemStartedAt,
             finishedAt: this.#now(),
-            errorCode: "security.scan.unchanged",
+            report: dto,
           };
-          newEntries.push(entry);
-          this.#state.progress.skipped += 1;
-          this.#state.resultIds.push(entry.id);
-          continue;
+          results.push({ index, entry });
+          this.#state.progress.completed += 1;
+        } catch {
+          if (!this.#isActive(id, epoch)) return;
+          const entry: SecurityScanHistoryEntry = {
+            id: `${id}:${target.skillRef.slice("skill:".length, "skill:".length + 16)}`,
+            scanId: id,
+            skillRef: target.skillRef,
+            skillName: target.name,
+            mode: request.mode,
+            trigger: request.trigger,
+            locale,
+            status: "failed",
+            startedAt: itemStartedAt,
+            finishedAt: this.#now(),
+            errorCode: "security.scanFailed",
+          };
+          results.push({ index, entry });
+          this.#state.progress.failed += 1;
         }
-        const scanRequest = {
-          mode: request.mode,
-          locale,
-          files: collected.files,
-          ...(config == null ? {} : { model: config }),
-        };
-        const scanner = this.#options.scanner ?? scanSkill;
-        const report = await scanner(scanRequest, {
-          fetch: createSecurityScannerFetch(),
-        });
-        if (!this.#isActive(id, epoch)) return;
-        const dto = sanitizeReport(
-          report,
-          config?.apiKey ? [config.apiKey] : [],
+        const done =
+          this.#state.progress.completed +
+          this.#state.progress.failed +
+          this.#state.progress.skipped;
+        this.#state.progress.percent = Math.floor(
+          (done / targets.length) * 100,
         );
-        if (collected.hostSkipped.length > 0) {
-          dto.status = "partial";
-          const hostPaths = new Set(
-            collected.hostSkipped.map((item) => item.path),
-          );
-          dto.skippedFiles = [
-            ...dto.skippedFiles.filter((item) => !hostPaths.has(item.path)),
-            ...collected.hostSkipped,
-          ];
-          if (dto.findings.length === 0) dto.verdict = "unknown";
-        }
-        finalizeTerminalPartialReport(dto);
-        const status = dto.status;
-        const entry: SecurityScanHistoryEntry = {
-          id: `${id}:${target.skillRef.slice("skill:".length, "skill:".length + 16)}`,
-          scanId: id,
-          skillRef: target.skillRef,
-          skillName: target.name,
-          mode: request.mode,
-          trigger: request.trigger,
-          locale,
-          status,
-          startedAt: itemStartedAt,
-          finishedAt: this.#now(),
-          report: dto,
-        };
-        newEntries.push(entry);
-        this.#state.progress.completed += 1;
-        this.#state.resultIds.push(entry.id);
-      } catch {
-        if (!this.#isActive(id, epoch)) return;
-        const entry: SecurityScanHistoryEntry = {
-          id: `${id}:${target.skillRef.slice("skill:".length, "skill:".length + 16)}`,
-          scanId: id,
-          skillRef: target.skillRef,
-          skillName: target.name,
-          mode: request.mode,
-          trigger: request.trigger,
-          locale,
-          status: "failed",
-          startedAt: itemStartedAt,
-          finishedAt: this.#now(),
-          errorCode: "security.scanFailed",
-        };
-        newEntries.push(entry);
-        this.#state.progress.failed += 1;
-        this.#state.resultIds.push(entry.id);
       }
-      const done =
-        this.#state.progress.completed +
-        this.#state.progress.failed +
-        this.#state.progress.skipped;
-      this.#state.progress.percent = Math.floor((done / targets.length) * 100);
+    };
+    await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
+    if (!this.#isActive(id, epoch)) return;
+    // A cancellation request only stops workers from picking new targets;
+    // Skills that never started are counted as skipped once in-flight work
+    // has drained, exactly like a cancelled sequential run.
+    if (this.#cancelRequested) {
+      this.#state.progress.skipped +=
+        targets.length - this.#state.progress.started;
+    }
+    // Deterministic commit order: completion races must not reshuffle history
+    // or resultIds, so entries are committed in discovery order — the same
+    // order a sequential run would have produced.
+    results.sort((left, right) => left.index - right.index);
+    for (const { entry } of results) {
+      newEntries.push(entry);
+      this.#state.resultIds.push(entry.id);
     }
     if (!this.#isActive(id, epoch)) return;
     if (newEntries.length > 0)

--- a/src/modules/dashboard/ai-insight.server.test.ts
+++ b/src/modules/dashboard/ai-insight.server.test.ts
@@ -401,13 +401,17 @@ test("TTL cache is read-only and concurrent refreshes are deduplicated", async (
 });
 
 test("allowlist projection strips an unexpected path-like project label", () => {
+  // createDashboardV2View resolves the "30d" preset against the live clock,
+  // so a fixed absolute timestamp would silently roll out of the rolling
+  // window as real time passes. Anchor the fixture a few days in the past.
+  const liveTimestamp = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000);
   const snapshot = {
-    generatedAt: "2026-08-10T00:00:00.000Z",
+    generatedAt: liveTimestamp.toISOString(),
     mode: "real",
     events: [
       {
         source: "codex",
-        timestamp: "2026-08-10T00:00:00.000Z",
+        timestamp: liveTimestamp.toISOString(),
         model: "gpt-5",
         project: "/Users/alice/private-project",
         inputTokens: 50,


### PR DESCRIPTION
## 变更内容
- `SecurityScannerService.#run` 从**严格串行**改为**有界并发工作池**：默认 4 并发（新增 `scanConcurrency` 选项，钳制 1–16）。full 模式下每个 Skill 会发出多次串行 LLM 请求，整库扫描是网络等待型任务，并发后总耗时约除以池宽度（实测 200+ Skill 场景从 5–6 小时降到约 1.5 小时级）。
- 行为保持不变：
  - 取消仍是 **between-skills**（在途 Skill 跑完，未开始的计入 skipped）；
  - 自动扫描的 unchanged 内容跳过逻辑不变；
  - 完成条目按发现顺序统一提交，**history/resultIds 顺序在并发竞争下仍然确定**；
  - 进度计数（started/completed/failed/skipped/percent）、clear/取消竞态语义不变。
- 新增 2 个回归测试（并发上限 + 确定性排序；并发下的取消）；electron 单测 136/136 通过，typecheck/lint 通过。

## 后续（不在此 PR）
- 依赖引擎新版本（single-shot 快路径，见 agent-threat-scanner PR #18）发布后升级 package.json 依赖即可进一步减少每次 Skill 的模型调用数。