### PR TITLE
fix(usage): retain per-source last-known-good so empty scans cannot zero data (#35)

### DIFF
--- a/src/app/composition.server.ts
+++ b/src/app/composition.server.ts
@@ -400,7 +400,25 @@ async function buildCompositionRoot(clock: Clock): Promise<CompositionRoot> {
       NonNullable<Parameters<typeof createUsageSnapshotRuntime>[0]["collect"]>
     >[0],
   ) => {
-    const collector = createUsageCollector();
+    // P2-3 + issue #35: the collector needs the last committed snapshot to (a)
+    // keep last-known-good when the whole scan is unhealthy and (b) retain
+    // per-source evidence for sources that previously had data but scanned
+    // empty this round. Persistence itself stays with the coordinator, so the
+    // collector's Dto-level `save` is deliberately a no-op here.
+    const collector = createUsageCollector({
+      repository: {
+        load: async () => {
+          try {
+            const hydrated =
+              await databaseRuntime.features.usageSnapshots.load();
+            return hydrated.envelope.data ?? undefined;
+          } catch {
+            return undefined;
+          }
+        },
+        save: async () => {},
+      },
+    });
     // P3-T3-04: reuse the shared WSL topology snapshot instead of re-running
     // `wsl.exe` on every usage refresh. The coordinator hydrates the
     // persisted topology once; a missing/stale snapshot triggers exactly one
@@ -449,6 +467,27 @@ async function buildCompositionRoot(clock: Clock): Promise<CompositionRoot> {
       const previous = request.previous?.data;
       if (previous == null) {
         if (result.cancelled) throw new Error("usage:cancelled");
+        return {
+          data: result.snapshot,
+          sourceFingerprint: result.snapshot.generatedAt,
+          scannedItems: 0,
+        };
+      }
+      return {
+        data: previous,
+        sourceFingerprint: request.previous?.sourceFingerprint ?? undefined,
+        scannedItems: 0,
+        reusedItems: 0,
+        staleRefreshed: true,
+      };
+    }
+    // Whole-snapshot unhealthy (all sources failed): the collector returned
+    // the last committed snapshot. Commit it as a stale-refreshed generation
+    // so its original generatedAt is preserved instead of being re-stamped
+    // fresh over data that was never recollected.
+    if (result.retainedPreviousSnapshot) {
+      const previous = request.previous?.data;
+      if (previous == null) {
         return {
           data: result.snapshot,
           sourceFingerprint: result.snapshot.generatedAt,

--- a/src/lib/local-usage/types.ts
+++ b/src/lib/local-usage/types.ts
@@ -31,7 +31,14 @@ export type LocalUsageDiagnosticCode =
   | "field-mismatch"
   | "malformed-json"
   | "query-failed"
-  | "read-failed";
+  | "read-failed"
+  /**
+   * Emitted by the usage collector when a source that previously reported
+   * data (or readable files) came back empty in this scan. The previous
+   * per-source evidence is retained in the committed snapshot so a single
+   * transiently failing scan can never silently zero a working source.
+   */
+  | "retained-previous";
 
 export interface LocalUsageDiagnostic {
   code: LocalUsageDiagnosticCode;

--- a/src/modules/usage/application/retain-source-evidence.test.ts
+++ b/src/modules/usage/application/retain-source-evidence.test.ts
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildLocalUsageSnapshot } from "../../../lib/local-usage/aggregate.ts";
+import type {
+  LocalUsageEvent,
+  LocalUsageSourceSummary,
+} from "../../../lib/local-usage/types.ts";
+import { compactUsageSnapshot } from "./aggregate-projection.ts";
+import {
+  RETAINED_PREVIOUS_CODE,
+  retainSourceEvidence,
+} from "./retain-source-evidence.ts";
+
+const counts = {
+  inputTokens: 100,
+  cachedInputTokens: 10,
+  cacheCreationInputTokens: 0,
+  outputTokens: 20,
+  reasoningOutputTokens: 5,
+  totalTokens: 135,
+};
+
+function event(
+  source: "pi" | "codex",
+  id: string,
+  timestamp: string,
+): LocalUsageEvent {
+  return {
+    source,
+    timestamp,
+    model: `model-${source}`,
+    project: `project-${source}`,
+    sessionId: `session-${source}-${id}`,
+    ...counts,
+  };
+}
+
+function row(
+  source: "pi" | "codex",
+  options: {
+    available?: boolean;
+    events: number;
+    filesRead?: number;
+    filesConsidered?: number;
+  },
+): LocalUsageSourceSummary {
+  const filesRead = options.filesRead ?? options.events;
+  return {
+    source,
+    available: options.available ?? options.events > 0,
+    filesConsidered: options.filesConsidered ?? filesRead,
+    filesRead,
+    filesReused: 0,
+    filesParsed: filesRead,
+    malformedLines: 0,
+    events: options.events,
+  };
+}
+
+function lifelessRow(source: "pi" | "codex"): LocalUsageSourceSummary {
+  return {
+    source,
+    available: false,
+    detected: false,
+    filesConsidered: 0,
+    filesRead: 0,
+    filesReused: 0,
+    filesParsed: 0,
+    malformedLines: 0,
+    events: 0,
+  };
+}
+
+function built(
+  events: LocalUsageEvent[],
+  sources: LocalUsageSourceSummary[],
+  generatedAt: Date = new Date("2026-09-01T00:00:00.000Z"),
+) {
+  return buildLocalUsageSnapshot(events, sources, generatedAt);
+}
+
+function persisted(
+  events: LocalUsageEvent[],
+  sources: LocalUsageSourceSummary[],
+  generatedAt?: Date,
+) {
+  return compactUsageSnapshot(built(events, sources, generatedAt));
+}
+
+test("retains previous per-source evidence when a source comes back lifeless", () => {
+  const previous = persisted(
+    [
+      event("pi", "a", "2026-08-06T10:00:00.000Z"),
+      event("pi", "b", "2026-08-06T11:00:00.000Z"),
+    ],
+    [row("pi", { events: 2, filesRead: 2 })],
+  );
+  const current = built(
+    [event("codex", "1", "2026-08-07T10:00:00.000Z")],
+    [row("codex", { events: 1 }), lifelessRow("pi")],
+    new Date("2026-09-02T00:00:00.000Z"),
+  );
+
+  const outcome = retainSourceEvidence(previous, current);
+  assert.ok(outcome, "pi had evidence before and reports none now");
+  assert.deepEqual(outcome.retainedSources, ["pi"]);
+
+  const snapshot = outcome.snapshot;
+  const pi = snapshot.sources.find((item) => item.source === "pi");
+  assert.ok(pi);
+  assert.equal(pi.available, true);
+  assert.equal(pi.events, 2);
+  assert.equal(pi.filesRead, 2);
+  assert.ok(
+    pi.diagnostics?.some((item) => item.code === RETAINED_PREVIOUS_CODE),
+    "retained row carries the retained-previous marker",
+  );
+  const codex = snapshot.sources.find((item) => item.source === "codex");
+  assert.equal(codex?.events, 1);
+  assert.ok(
+    !codex?.diagnostics?.some((item) => item.code === RETAINED_PREVIOUS_CODE),
+    "healthy sources are not marked",
+  );
+
+  // Aggregates stay consistent across every derived layer.
+  assert.equal(snapshot.totals.events, 3);
+  const bySource = new Map(snapshot.bySource.map((item) => [item.key, item]));
+  assert.equal(bySource.get("pi")?.events, 2);
+  assert.equal(bySource.get("codex")?.events, 1);
+  const byModel = new Map(snapshot.byModel.map((item) => [item.key, item]));
+  assert.equal(byModel.get("model-pi")?.events, 2);
+  assert.equal(byModel.get("model-codex")?.events, 1);
+  assert.equal(snapshot.daily.length, 2);
+  const [first, second] = snapshot.daily;
+  assert.equal(first.date, "2026-08-06");
+  assert.equal(first.events, 2);
+  assert.equal(first.bySource["pi"]?.inputTokens, 200);
+  assert.equal(second.date, "2026-08-07");
+  assert.equal(second.events, 1);
+  assert.equal(snapshot.mode, "real");
+});
+
+test("fresh evidence is never replaced by previous evidence", () => {
+  const previous = persisted(
+    [event("pi", "old", "2026-08-06T10:00:00.000Z")],
+    [row("pi", { events: 1 })],
+  );
+  const current = built(
+    [event("pi", "new", "2026-08-08T10:00:00.000Z")],
+    [row("pi", { events: 1, filesRead: 4 })],
+    new Date("2026-09-02T00:00:00.000Z"),
+  );
+  const outcome = retainSourceEvidence(previous, current);
+  assert.equal(outcome, null, "a source that scanned data must stay fresh");
+});
+
+test("sources without previous evidence are never retained", () => {
+  const previous = persisted(
+    [event("pi", "a", "2026-08-06T10:00:00.000Z")],
+    [
+      row("pi", { events: 1 }),
+      { ...lifelessRow("codex"), available: false, detected: false },
+    ],
+  );
+  const current = built(
+    [],
+    [lifelessRow("pi"), lifelessRow("codex")],
+    new Date("2026-09-02T00:00:00.000Z"),
+  );
+  const outcome = retainSourceEvidence(previous, current);
+  assert.ok(outcome);
+  assert.deepEqual(outcome.retainedSources, ["pi"]);
+  const retained = outcome.snapshot.sources.find(
+    (item) => item.source === "pi",
+  );
+  assert.equal(retained?.events, 1);
+  const codex = outcome.snapshot.sources.find(
+    (item) => item.source === "codex",
+  );
+  assert.equal(codex?.events, 0);
+});
+
+test("a snapshot without persisted buckets cannot retain anything", () => {
+  const previous = built(
+    [event("pi", "a", "2026-08-06T10:00:00.000Z")],
+    [row("pi", { events: 1 })],
+  );
+  const current = built(
+    [event("codex", "1", "2026-08-07T10:00:00.000Z")],
+    [row("codex", { events: 1 }), lifelessRow("pi")],
+  );
+  const outcome = retainSourceEvidence(previous, current);
+  assert.equal(outcome, null);
+});
+
+test("an empty previous snapshot never masks a first real scan", () => {
+  const previous = persisted([], [lifelessRow("pi")]);
+  const current = built(
+    [event("pi", "first", "2026-08-07T10:00:00.000Z")],
+    [row("pi", { events: 1 })],
+  );
+  const outcome = retainSourceEvidence(previous, current);
+  assert.equal(outcome, null);
+});

--- a/src/modules/usage/application/retain-source-evidence.ts
+++ b/src/modules/usage/application/retain-source-evidence.ts
@@ -1,0 +1,147 @@
+/**
+ * Per-source last-known-good retention for usage snapshots.
+ *
+ * Why this exists (issue #35): the Usage snapshot is whole-generation
+ * replaced on every successful collection. When one source — say `pi` after a
+ * data-directory override whose rebased layout does not exist — scans to zero
+ * files while other sources stay healthy, the zero result used to be committed
+ * unconditionally: the collector's "keep the last snapshot" guard only fires
+ * when the WHOLE snapshot is unhealthy, and the Sources cards read exactly
+ * this snapshot, so a single transiently failing scan silently zeroed a
+ * previously working tool (and every 5-minute scheduled refresh re-stamped
+ * the zero).
+ *
+ * This module protects the *per-source* level: when the previous committed
+ * snapshot carries evidence for a source (events or readable files) and the
+ * new scan reports that source lifeless (no files, no events, not detected),
+ * the previous source row and its aggregate buckets are merged into the new
+ * snapshot instead of being dropped. Sources that did scan fresh data are
+ * never touched, so a repaired data directory converges on the next good
+ * scan. Retained rows carry a `retained-previous` diagnostic so operators can
+ * tell "kept last known good" apart from "freshly collected".
+ *
+ * The merge happens at the persisted bucket granularity
+ * (`compactUsageSnapshot` / `buildUsageSnapshotFromProjection`), so every
+ * derived aggregate (totals, bySource/byModel/byProject, daily) stays
+ * mutually consistent without re-deriving from per-event detail rows.
+ */
+
+import type {
+  LocalUsageSource,
+  LocalUsageSourceSummary,
+} from "../../../lib/local-usage/types.ts";
+import type { UsageSnapshotDto } from "../contracts.ts";
+import {
+  buildUsageSnapshotFromProjection,
+  compactUsageSnapshot,
+} from "./aggregate-projection.ts";
+
+export const RETAINED_PREVIOUS_CODE = "retained-previous" as const;
+
+export interface SourceRetentionOutcome {
+  /** Merged snapshot ready to be committed in place of the raw scan result. */
+  readonly snapshot: UsageSnapshotDto;
+  /** Sources whose previous evidence was carried into the new snapshot. */
+  readonly retainedSources: readonly LocalUsageSource[];
+}
+
+function markerDiagnostic(
+  source: LocalUsageSource,
+): NonNullable<LocalUsageSourceSummary["diagnostics"]>[number] {
+  return {
+    source,
+    code: RETAINED_PREVIOUS_CODE,
+    count: 1,
+    message: `usage.${RETAINED_PREVIOUS_CODE}`,
+  };
+}
+
+/** A source row is "evidence" when it reported data or readable files. */
+function hasEvidence(row: LocalUsageSourceSummary | undefined): boolean {
+  if (row == null) return false;
+  return (
+    row.available === true ||
+    (row.events ?? 0) > 0 ||
+    (row.filesRead ?? 0) > 0 ||
+    (row.filesConsidered ?? 0) > 0
+  );
+}
+
+/** A source row is lifeless when this scan found nothing attributable. */
+function isLifeless(row: LocalUsageSourceSummary | undefined): boolean {
+  if (row == null) return true;
+  return (
+    row.available !== true &&
+    row.detected !== true &&
+    (row.events ?? 0) === 0 &&
+    (row.filesRead ?? 0) === 0 &&
+    (row.filesConsidered ?? 0) === 0
+  );
+}
+
+/**
+ * Merge the previous committed snapshot's per-source evidence into the fresh
+ * scan result for every source that had evidence before and reports none now.
+ * Returns null when nothing needs protecting (no previous evidence shape, no
+ * lifeless source with previous evidence, or no persisted buckets to carry).
+ *
+ * `previous` must be a persisted-shape snapshot (carrying `aggregateBuckets`);
+ * freshly scanned snapshots have no buckets and are always used verbatim.
+ */
+export function retainSourceEvidence(
+  previous: UsageSnapshotDto,
+  current: UsageSnapshotDto,
+): SourceRetentionOutcome | null {
+  const previousBuckets = previous.aggregateBuckets;
+  if (previousBuckets == null || previousBuckets.length === 0) return null;
+  const previousRows = new Map(
+    previous.sources.map((row) => [row.source, row] as const),
+  );
+  const currentRows = new Map(
+    current.sources.map((row) => [row.source, row] as const),
+  );
+
+  const retained: LocalUsageSource[] = [];
+  for (const previousRow of previousRows.values()) {
+    if (!hasEvidence(previousRow)) continue;
+    if (isLifeless(currentRows.get(previousRow.source))) {
+      retained.push(previousRow.source);
+    }
+  }
+  if (retained.length === 0) return null;
+
+  const retainedSet = new Set<LocalUsageSource>(retained);
+  const currentCompacted = compactUsageSnapshot(current);
+  const mergedBuckets = [
+    ...(currentCompacted.aggregateBuckets ?? []),
+    ...previousBuckets.filter((bucket) => retainedSet.has(bucket.source)),
+  ];
+  const previousTracker = previous.trackerBuckets ?? [];
+  const mergedTracker = [
+    ...(currentCompacted.trackerBuckets ?? []),
+    ...previousTracker.filter((bucket) => retainedSet.has(bucket.source)),
+  ];
+  const mergedSources = current.sources.map((row) => {
+    if (!retainedSet.has(row.source)) return row;
+    const previousRow = previousRows.get(row.source);
+    if (previousRow == null) return row;
+    return {
+      ...previousRow,
+      diagnostics: [
+        ...(previousRow.diagnostics ?? []),
+        markerDiagnostic(row.source),
+      ],
+    };
+  });
+
+  const rebuilt = buildUsageSnapshotFromProjection({
+    generatedAt: current.generatedAt,
+    sources: mergedSources,
+    buckets: mergedBuckets,
+    trackerBuckets: mergedTracker,
+  });
+  return {
+    snapshot: { ...rebuilt, details: current.details, recent: current.recent },
+    retainedSources: retained,
+  };
+}

--- a/src/modules/usage/infrastructure/usage-collector.server.test.ts
+++ b/src/modules/usage/infrastructure/usage-collector.server.test.ts
@@ -1,7 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { buildLocalUsageSnapshot } from "../../../lib/local-usage/aggregate.ts";
+import type {
+  LocalUsageEvent,
+  LocalUsageSourceSummary,
+} from "../../../lib/local-usage/types.ts";
 import { usageSnapshotFixture } from "../../../test-support/output-baseline.ts";
+import { compactUsageSnapshot } from "../application/aggregate-projection.ts";
+import { RETAINED_PREVIOUS_CODE } from "../application/retain-source-evidence.ts";
 import type { UsageSnapshotDto } from "../contracts.ts";
 import { createUsageCollector } from "./usage-collector.server.ts";
 import { toPublicUsageSnapshot } from "./usage-adapter.server.ts";
@@ -138,4 +145,156 @@ test("abort signal returns a safe empty result when no snapshot exists", async (
   const result = await collector.collect({ signal: controller.signal });
   assert.equal(result.cancelled, true);
   assert.equal(result.snapshot.mode, "empty");
+});
+
+const tokenCounts = {
+  inputTokens: 100,
+  cachedInputTokens: 10,
+  cacheCreationInputTokens: 0,
+  outputTokens: 20,
+  reasoningOutputTokens: 5,
+  totalTokens: 135,
+};
+
+function retentionEvent(
+  source: "pi" | "codex",
+  timestamp: string,
+): LocalUsageEvent {
+  return {
+    source,
+    timestamp,
+    model: `model-${source}`,
+    project: `project-${source}`,
+    sessionId: `session-${source}-1`,
+    ...tokenCounts,
+  };
+}
+
+function retentionRow(source: "pi" | "codex"): LocalUsageSourceSummary {
+  return {
+    source,
+    available: true,
+    filesConsidered: 1,
+    filesRead: 1,
+    filesReused: 0,
+    filesParsed: 1,
+    malformedLines: 0,
+    events: 1,
+  };
+}
+
+function lifelessRetentionRow(source: "pi" | "codex"): LocalUsageSourceSummary {
+  return {
+    source,
+    available: false,
+    detected: false,
+    filesConsidered: 0,
+    filesRead: 0,
+    filesReused: 0,
+    filesParsed: 0,
+    malformedLines: 0,
+    events: 0,
+  };
+}
+
+test("a previously healthy source scanning empty keeps its last evidence", async () => {
+  const previous = compactUsageSnapshot(
+    buildLocalUsageSnapshot(
+      [retentionEvent("pi", "2026-08-06T10:00:00.000Z")],
+      [retentionRow("pi")],
+      new Date("2026-09-01T00:00:00.000Z"),
+    ),
+  );
+  const store = repository(previous);
+  const collector = createUsageCollector({
+    repository: store,
+    scanner: {
+      // pi is now lifeless (e.g. data-directory override rebased to a
+      // non-existent layout) while codex keeps the snapshot healthy.
+      scan: async () =>
+        buildLocalUsageSnapshot(
+          [retentionEvent("codex", "2026-08-07T10:00:00.000Z")],
+          [retentionRow("codex"), lifelessRetentionRow("pi")],
+          new Date("2026-09-02T00:00:00.000Z"),
+        ),
+    },
+  });
+
+  const result = await collector.collect();
+  assert.equal(result.retainedPreviousSnapshot, false);
+  assert.equal(result.health.status, "healthy");
+  const pi = result.snapshot.sources.find((item) => item.source === "pi");
+  assert.ok(pi, "pi row survives the empty scan");
+  assert.equal(pi.events, 1);
+  assert.equal(pi.filesRead, 1);
+  assert.ok(
+    pi.diagnostics?.some((item) => item.code === RETAINED_PREVIOUS_CODE),
+    "kept evidence is marked with retained-previous",
+  );
+  assert.equal(result.snapshot.totals.events, 2, "pi + codex evidence totals");
+  assert.ok(store.value, "collector must persist the merged snapshot");
+  assert.ok(
+    store.value.sources.some(
+      (item) =>
+        item.source === "pi" &&
+        item.events === 1 &&
+        item.diagnostics?.some(
+          (diagnostic) => diagnostic.code === RETAINED_PREVIOUS_CODE,
+        ),
+    ),
+    "the merged snapshot is what gets persisted",
+  );
+});
+
+test("a source that scanned fresh data replaces its previous evidence", async () => {
+  const previous = compactUsageSnapshot(
+    buildLocalUsageSnapshot(
+      [retentionEvent("pi", "2026-08-06T10:00:00.000Z")],
+      [retentionRow("pi")],
+      new Date("2026-09-01T00:00:00.000Z"),
+    ),
+  );
+  const current = buildLocalUsageSnapshot(
+    [retentionEvent("pi", "2026-08-08T10:00:00.000Z")],
+    [retentionRow("pi")],
+    new Date("2026-09-02T00:00:00.000Z"),
+  );
+  const store = repository(previous);
+  const collector = createUsageCollector({
+    repository: store,
+    scanner: { scan: async () => current },
+  });
+  const result = await collector.collect();
+  const pi = result.snapshot.sources.find((item) => item.source === "pi");
+  assert.ok(pi);
+  assert.equal(pi.events, 1);
+  assert.ok(
+    !pi.diagnostics?.some((item) => item.code === RETAINED_PREVIOUS_CODE),
+  );
+  assert.equal(result.snapshot.generatedAt, current.generatedAt);
+});
+
+test("lifeless sources without previous evidence stay zero", async () => {
+  const previous = compactUsageSnapshot(
+    buildLocalUsageSnapshot([], [], new Date("2026-09-01T00:00:00.000Z")),
+  );
+  const current = buildLocalUsageSnapshot(
+    [retentionEvent("codex", "2026-08-07T10:00:00.000Z")],
+    [retentionRow("codex"), lifelessRetentionRow("pi")],
+    new Date("2026-09-02T00:00:00.000Z"),
+  );
+  const store = repository(previous);
+  const collector = createUsageCollector({
+    repository: store,
+    scanner: { scan: async () => current },
+  });
+  const result = await collector.collect();
+  const pi = result.snapshot.sources.find((item) => item.source === "pi");
+  const codex = result.snapshot.sources.find((item) => item.source === "codex");
+  assert.equal(pi?.events, 0, "pi never had evidence, nothing to retain");
+  assert.ok(
+    !pi?.diagnostics?.some((item) => item.code === RETAINED_PREVIOUS_CODE),
+  );
+  assert.equal(codex?.events, 1, "codex scanned fresh data");
+  assert.equal(result.snapshot.generatedAt, current.generatedAt);
 });

--- a/src/modules/usage/infrastructure/usage-collector.server.ts
+++ b/src/modules/usage/infrastructure/usage-collector.server.ts
@@ -12,6 +12,7 @@ import {
   toPublicUsageSnapshot,
   type UsageScanner,
 } from "./usage-adapter.server.ts";
+import { retainSourceEvidence } from "../application/retain-source-evidence.ts";
 import { isCancellation } from "../../../platform/runtime/abort.ts";
 
 export interface UsageCollectorOptions {
@@ -186,23 +187,37 @@ export function createUsageCollector(
         }
         const snapshot = toPublicUsageSnapshot(outcome.value);
         const currentHealth = health(snapshot);
-        if (currentHealth.status !== "healthy" && options.repository != null) {
-          const previous = await options.repository.load();
-          if (previous != null) {
-            return {
-              snapshot: previous,
-              health: currentHealth,
-              durationMs: Math.max(0, now() - startedAt),
-              budgetExhausted: false,
-              cancelled: false,
-              retainedPreviousSnapshot: true,
-            };
-          }
+        const previous =
+          options.repository == null
+            ? undefined
+            : await options.repository.load();
+        if (currentHealth.status !== "healthy" && previous != null) {
+          return {
+            snapshot: previous,
+            health: currentHealth,
+            durationMs: Math.max(0, now() - startedAt),
+            budgetExhausted: false,
+            cancelled: false,
+            retainedPreviousSnapshot: true,
+          };
         }
-        await options.repository?.save(snapshot);
+        // Issue #35: per-source protection. A whole-snapshot "healthy" guard
+        // (above) only protects against a fully empty scan. When the scan is
+        // healthy overall but one previously-working source came back lifeless
+        // (e.g. a data-directory override whose rebased layout does not exist,
+        // or a transiently failing enumeration), the previous evidence for
+        // exactly those sources is merged into the committed snapshot instead
+        // of being silently replaced with zeros.
+        let committed = snapshot;
+        if (previous != null) {
+          const retention = retainSourceEvidence(previous, committed);
+          if (retention != null) committed = retention.snapshot;
+        }
+        const committedHealth = health(committed);
+        await options.repository?.save(committed);
         return {
-          snapshot,
-          health: currentHealth,
+          snapshot: committed,
+          health: committedHealth,
           durationMs: Math.max(0, now() - startedAt),
           budgetExhausted: false,
           cancelled: false,


### PR DESCRIPTION
## 背景

[issue #35](https://github.com/estelwalks/aitracker/issues/35)：Agent 卡片（Sources）读的是 Usage 快照，而该快照每次采集成功都会**整代替换**。当某个来源本次扫出 0 文件、而快照整体因其他来源保持健康时，0/0 会被无条件提交并持久化；之后每 5 分钟的定时刷新还会反复固化零态，直到手动修正目录配置。今日洞察（sessions 域）不受影响，因此呈现“洞察正常、卡片 0/0”。

复现（macOS 端到端 + Windows 侧 `aitracker-issue35/` 记录均验证）：
- usage/sessions 是两个独立快照域，只有 usage 感知 per-tool 数据目录覆盖；
- 覆盖目录被 rebase 拼接（如把内层 `agent/sessions` 目录当作数据根时 → `<override>/agent/sessions` 不存在 → stat 失败 → 静默 0 文件）；
- collector 的“整快照不健康才保留 LKG”守卫在真实运行路径是死代码（`composition.server.ts` 从未注入 repository）→ 零结果无条件覆盖好数据。

## 修复

1. **注入 repository**：`composition.server.ts` 为 `createUsageCollector` 提供 Dto 级读取适配器（持久化仍由 coordinator 负责），使整快照 LKG 守卫在生产路径真正生效。
2. **stale-refreshed 语义**：整快照保留提交标记 `staleRefreshed`，保留原始 `generatedAt`，不再把从未采集的数据重新盖“fresh”时间戳。
3. **per-source 保留**（核心，新增 `src/modules/usage/application/retain-source-evidence.ts`）：上一代有证据（events/文件数>0）的来源，若本次扫描“无生命迹象”（0 文件、0 事件、未探测），则把其上一代 source 行与 aggregate/tracker buckets 并入本次提交，并打 `retained-previous` 诊断标记；扫到新数据的来源一律用新数据，修好目录后下一轮即收敛。
4. 测试：新增纯函数单测（bucket 级合并一致性、标记、边界）与 collector 级集成测试。

## 验证

- 单测：新增 5 + 扩展 3；usage 全模块 42、snapshot-runtime/sources 47、composition/bootstrap 26 全通过；`tsc`（web+electron）与 `eslint --fix` 干净。
- 端到端（Mac，假 HOME 复刻 issue 环境）：修复前同场景 pi 被提交为 `0/0`；修复后 pi 保持 `2/2`，`usage_aggregate_source_diagnostics` 出现 `retained-previous`，UI 卡片维持「Has data · Files read 2 / 2」。

## 设计取舍

- 首次运行（无上一代）仍如实提交 0；全空扫描走整体 LKG（stale 提交）不再覆盖好数据。
- 保留行带 DB 级 `retained-previous` 标记，可被 health/issueCodes 体系消费；Sources 卡片暂无专门 UI 文案（可后续补充）。