### PR TITLE
feat(release): publish a Windows arm64 installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,16 @@ jobs:
             command: npm run dist:win:x64
             artifact_glob: release/*.exe
             artifact_name: release-windows-x64
+          # Windows on ARM is cross-built on the x64 runner: electron-builder
+          # downloads the win32-arm64 Electron payload and NSIS emits a
+          # separate AITracker-Setup-<version>-arm64.exe. No ARM64 runner is
+          # required to produce the installer.
+          - name: Windows arm64
+            os: windows-latest
+            platform: win32-arm64
+            command: npm run dist:win:arm64
+            artifact_glob: release/*.exe
+            artifact_name: release-windows-arm64
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     env:
@@ -134,7 +144,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Download the three installers
+      - name: Download the four installers
         uses: actions/download-artifact@v4
         with:
           pattern: release-*
@@ -204,7 +214,7 @@ jobs:
 
           ## Release assets
 
-          This release includes unsigned macOS arm64/x64 DMG installers, a Windows x64 NSIS installer, `release-metadata.json`, and `checksums.txt`. Verify the published SHA-256 checksums before installation.
+          This release includes unsigned macOS arm64/x64 DMG installers, Windows x64 and Windows arm64 NSIS installers, `release-metadata.json`, and `checksums.txt`. Verify the published SHA-256 checksums before installation.
 
           macOS Gatekeeper or Windows SmartScreen may show a warning because these installers are not signed or notarized. Follow the operating system's normal per-file confirmation flow and do not disable global security settings.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to AITracker will be documented in this file. The project
 uses semantic versioning for published releases.
 
+## [Unreleased]
+
+- The tag-triggered release workflow now publishes a Windows arm64 NSIS
+  installer alongside the existing macOS arm64/x64 and Windows x64 ones
+  (`AITracker-Setup-<version>-arm64.exe`). The Windows arm64 build is
+  cross-built on the x64 runner: NSIS embeds the native win32-arm64 Electron
+  payload while the installer stub itself stays x86 and runs under Windows'
+  x86 emulation, so no ARM64 runner is required.
+- `win32-arm64` joined the release contract: `release-metadata.json`, the
+  `release-metadata.schema.json` artifact map, and the `npx` installer
+  launcher now resolve Windows on ARM to its own installer instead of falling
+  back to the x64 one.
+
 ## [1.0.1] - 2026-09-08
 
 - Added pi and oh-my-pi (omp) session and usage readers over their `~/.pi`

--- a/README.md
+++ b/README.md
@@ -75,11 +75,14 @@ To run the browser development server only, use `npm run dev`.
 You can download the installer of the latest release directly:
 
 - macOS (Apple Silicon):
-  [AITracker-1.0.0-arm64.dmg](https://github.com/estelwalks/aitracker/releases/download/v1.0.1/AITracker-1.0.0-arm64.dmg)
+  [AITracker-1.0.1-arm64.dmg](https://github.com/estelwalks/aitracker/releases/download/v1.0.1/AITracker-1.0.1-arm64.dmg)
 - macOS (Intel):
-  [AITracker-1.0.0-x64.dmg](https://github.com/estelwalks/aitracker/releases/download/v1.0.1/AITracker-1.0.0-x64.dmg)
+  [AITracker-1.0.1-x64.dmg](https://github.com/estelwalks/aitracker/releases/download/v1.0.1/AITracker-1.0.1-x64.dmg)
 - Windows (x64):
-  [AITracker-Setup-1.0.0-x64.exe](https://github.com/estelwalks/aitracker/releases/download/v1.0.1/AITracker-Setup-1.0.0-x64.exe)
+  [AITracker-Setup-1.0.1-x64.exe](https://github.com/estelwalks/aitracker/releases/download/v1.0.1/AITracker-Setup-1.0.1-x64.exe)
+- Windows (ARM64): the ARM64 installer is published from the next tagged
+  release onward —
+  [Releases page](https://github.com/estelwalks/aitracker/releases/latest)
 
 All releases are listed on the
 [Releases page](https://github.com/estelwalks/aitracker/releases/latest).
@@ -134,12 +137,13 @@ npm run test:all            # Unit, tooling, database, and scanner tests
 npm run check:opensource-hygiene
 ```
 
-Platform installers can be produced with `npm run dist:mac` or
-`npm run dist:win:x64`. Signing and notarization credentials are not stored in
-this repository.
+Platform installers can be produced with `npm run dist:mac`,
+`npm run dist:win:x64`, or `npm run dist:win:arm64`. Signing and notarization
+credentials are not stored in this repository.
 
 The standalone installer launcher is packaged as `aitracker` and supports
-macOS arm64/x64 and Windows x64. Linux is not supported by the launcher.
+macOS arm64/x64 and Windows x64/arm64 (including Windows on ARM). Linux is not
+supported by the launcher.
 
 See [Development Guide](docs/DEVELOPMENT.md) for the complete command matrix,
 generated-file policy, and repository layout.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -5,18 +5,18 @@ checkout.
 
 ## Repository layout
 
-| Path                            | Purpose                                                         |
-| ------------------------------- | --------------------------------------------------------------- |
-| `src/`                          | TanStack Start application and shared product modules           |
-| `electron/`                     | Desktop process, preload bridge, tray, and native integration   |
+| Path                               | Purpose                                                         |
+| ---------------------------------- | --------------------------------------------------------------- |
+| `src/`                             | TanStack Start application and shared product modules           |
+| `electron/`                        | Desktop process, preload bridge, tray, and native integration   |
 | `@estelwalks/agent-threat-scanner` | Published npm package used by security scanning                 |
-| `scripts/`                      | Code generation, validation, packaging, and performance tooling |
-| `tests/e2e/`                    | Playwright end-to-end scenarios                                 |
-| `tests/fixtures/`               | Versioned deterministic test fixtures                           |
-| `tests/performance/`            | Performance budgets and scenarios                               |
-| `build/`                        | Electron packaging inputs plus ignored generated bundles        |
-| `public/`                       | Static assets copied into the web application                   |
-| `.github/`                      | CI and collaboration templates                                  |
+| `scripts/`                         | Code generation, validation, packaging, and performance tooling |
+| `tests/e2e/`                       | Playwright end-to-end scenarios                                 |
+| `tests/fixtures/`                  | Versioned deterministic test fixtures                           |
+| `tests/performance/`               | Performance budgets and scenarios                               |
+| `build/`                           | Electron packaging inputs plus ignored generated bundles        |
+| `public/`                          | Static assets copied into the web application                   |
+| `.github/`                         | CI and collaboration templates                                  |
 
 ## Install
 
@@ -112,8 +112,14 @@ npm run verify:release-contract -- --tag v1.0.0-beta.1 --channel beta \
 ```
 
 The tag-triggered [unsigned beta release workflow](../.github/workflows/release.yml)
-uses Node 24 and `npm ci` to build macOS arm64/x64 and Windows x64 installers.
-It runs the same gate before packaging, assembles the installers, and creates
+uses Node 24 and `npm ci` to build macOS arm64/x64 and Windows x64/arm64
+installers. The Windows arm64 installer is cross-built on the x64 runner: NSIS
+embeds the native win32-arm64 Electron payload, while the installer stub itself
+stays x86 and runs under Windows' x86 emulation. That emulated stub also means
+the arm64 package defaults to `C:\Program Files (x86)\AITracker` instead of
+`C:\Program Files\AITracker` — see the `perMachine` note in
+[electron-builder.yml](../electron-builder.yml). It runs the same gate before
+packaging, assembles the installers, and creates
 only a GitHub draft prerelease with metadata and checksums. It does not sign or
 notarize artifacts, publish npm packages, or update a Homebrew Tap. A
 maintainer must inspect the draft, installers, metadata, and checksums before
@@ -121,7 +127,7 @@ manually publishing it; a failed workflow does not publish a formal/stable
 release channel.
 
 Unsigned local packages are suitable for testing. Phase 1 is limited to an
-unsigned beta for macOS x64/arm64 and Windows x64. The CLI tarball, release
+unsigned beta for macOS x64/arm64 and Windows x64/arm64. The CLI tarball, release
 metadata, and Cask generator are release-tooling inputs and are not yet
 published to npm or a Tap by this checkout. When those local tools are
 available, the expected dry-run sequence is:
@@ -130,6 +136,7 @@ available, the expected dry-run sequence is:
 # Build local installers, then generate one local source of release metadata.
 npm run dist:mac
 npm run dist:win:x64
+npm run dist:win:arm64
 node scripts/release-metadata.mjs --release-dir release \
   --version 1.0.0-beta.1 --channel beta \
   --output release/release-metadata.json

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -70,11 +70,13 @@ npm run dev:desktop
 也可以直接下载最新 Release 的安装包：
 
 - macOS（Apple Silicon）：
-  [AITracker-1.0.0-arm64.dmg](https://github.com/estelwalks/aitracker/releases/download/v1.0.1/AITracker-1.0.0-arm64.dmg)
+  [AITracker-1.0.1-arm64.dmg](https://github.com/estelwalks/aitracker/releases/download/v1.0.1/AITracker-1.0.1-arm64.dmg)
 - macOS（Intel）：
-  [AITracker-1.0.0-x64.dmg](https://github.com/estelwalks/aitracker/releases/download/v1.0.1/AITracker-1.0.0-x64.dmg)
+  [AITracker-1.0.1-x64.dmg](https://github.com/estelwalks/aitracker/releases/download/v1.0.1/AITracker-1.0.1-x64.dmg)
 - Windows（x64）：
-  [AITracker-Setup-1.0.0-x64.exe](https://github.com/estelwalks/aitracker/releases/download/v1.0.1/AITracker-Setup-1.0.0-x64.exe)
+  [AITracker-Setup-1.0.1-x64.exe](https://github.com/estelwalks/aitracker/releases/download/v1.0.1/AITracker-Setup-1.0.1-x64.exe)
+- Windows（ARM64）：ARM64 安装包从下一个 tag 版本开始发布，见
+  [Releases 页面](https://github.com/estelwalks/aitracker/releases/latest)
 
 所有版本可以在 [Releases 页面](https://github.com/estelwalks/aitracker/releases/latest) 查看。
 

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -72,11 +72,13 @@ npm run dev:desktop
 最新リリースのインストーラーを直接ダウンロードすることもできます：
 
 - macOS（Apple Silicon）：
-  [AITracker-1.0.0-arm64.dmg](https://github.com/estelwalks/aitracker/releases/download/v1.0.1/AITracker-1.0.0-arm64.dmg)
+  [AITracker-1.0.1-arm64.dmg](https://github.com/estelwalks/aitracker/releases/download/v1.0.1/AITracker-1.0.1-arm64.dmg)
 - macOS（Intel）：
-  [AITracker-1.0.0-x64.dmg](https://github.com/estelwalks/aitracker/releases/download/v1.0.1/AITracker-1.0.0-x64.dmg)
+  [AITracker-1.0.1-x64.dmg](https://github.com/estelwalks/aitracker/releases/download/v1.0.1/AITracker-1.0.1-x64.dmg)
 - Windows（x64）：
-  [AITracker-Setup-1.0.0-x64.exe](https://github.com/estelwalks/aitracker/releases/download/v1.0.1/AITracker-Setup-1.0.0-x64.exe)
+  [AITracker-Setup-1.0.1-x64.exe](https://github.com/estelwalks/aitracker/releases/download/v1.0.1/AITracker-Setup-1.0.1-x64.exe)
+- Windows（ARM64）：ARM64 インストーラーは次のタグ付きリリースから公開されます。
+  [Releases ページ](https://github.com/estelwalks/aitracker/releases/latest) を参照してください。
 
 すべてのリリースは [Releases ページ](https://github.com/estelwalks/aitracker/releases/latest) で確認できます。
 

--- a/docs/README_KO.md
+++ b/docs/README_KO.md
@@ -72,11 +72,13 @@ npm run dev:desktop
 최신 릴리스의 설치 파일을 직접 다운로드할 수도 있습니다:
 
 - macOS(Apple Silicon):
-  [AITracker-1.0.0-arm64.dmg](https://github.com/estelwalks/aitracker/releases/download/v1.0.1/AITracker-1.0.0-arm64.dmg)
+  [AITracker-1.0.1-arm64.dmg](https://github.com/estelwalks/aitracker/releases/download/v1.0.1/AITracker-1.0.1-arm64.dmg)
 - macOS(Intel):
-  [AITracker-1.0.0-x64.dmg](https://github.com/estelwalks/aitracker/releases/download/v1.0.1/AITracker-1.0.0-x64.dmg)
+  [AITracker-1.0.1-x64.dmg](https://github.com/estelwalks/aitracker/releases/download/v1.0.1/AITracker-1.0.1-x64.dmg)
 - Windows(x64):
-  [AITracker-Setup-1.0.0-x64.exe](https://github.com/estelwalks/aitracker/releases/download/v1.0.1/AITracker-Setup-1.0.0-x64.exe)
+  [AITracker-Setup-1.0.1-x64.exe](https://github.com/estelwalks/aitracker/releases/download/v1.0.1/AITracker-Setup-1.0.1-x64.exe)
+- Windows(ARM64): ARM64 설치 프로그램은 다음 태그 릴리스부터 제공됩니다.
+  [Releases 페이지](https://github.com/estelwalks/aitracker/releases/latest)를 확인하세요.
 
 모든 버전은 [Releases 페이지](https://github.com/estelwalks/aitracker/releases/latest)에서 확인할 수 있습니다.
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -40,10 +40,10 @@ npm run test:e2e:offline
 - Build the target installer with the appropriate `dist:*` command. Experimental
   beta releases may remain unsigned; stable releases must be signed and
   notarized/smoke-tested for the target platform.
-- For Phase 1, confirm the target set is macOS x64/arm64 and Windows x64;
-  Linux is out of scope. Keep the beta channel separate from stable.
+- For Phase 1, confirm the target set is macOS x64/arm64 and Windows
+  x64/arm64; Linux is out of scope. Keep the beta channel separate from stable.
 - The tag-triggered [unsigned beta release workflow](../.github/workflows/release.yml)
-  runs the version gate first, builds the three installers on platform
+  runs the version gate first, builds the four installers on platform
   runners, verifies their electron-builder names, and generates
   `release/release-metadata.json` plus `release/checksums.txt`.
 - The workflow creates a draft prerelease and uploads assets without the

--- a/docs/design/aitracker-架构设计文档.md
+++ b/docs/design/aitracker-架构设计文档.md
@@ -98,7 +98,7 @@ AITracker 当前通过 Electron Builder 生成 macOS DMG 和 Windows NSIS 安装
 flowchart LR
     Tag[受保护版本标签] --> Gate[质量与版本门禁]
     Gate --> Mac[macOS x64/arm64 构建、稳定版签名公证]
-    Gate --> Win[Windows x64 构建、稳定版签名]
+    Gate --> Win[Windows x64/arm64 构建、稳定版签名]
     Mac --> Meta[Release Metadata 生成器]
     Win --> Meta
     Meta --> GH[GitHub Draft Release]
@@ -156,6 +156,14 @@ flowchart LR
       "url": "<immutable-url>",
       "sha256": "<hex>",
       "size": 0
+    },
+    "win32-arm64": {
+      "name": "AITracker-Setup-1.0.0-arm64.exe",
+      "url": "<immutable-url>",
+      "sha256": "<hex>",
+      "size": 0,
+      "installerType": "nullsoft",
+      "scope": "machine"
     },
     "win32-x64": {
       "name": "AITracker-Setup-1.0.0-x64.exe",
@@ -225,11 +233,11 @@ Cask 使用当前两份版本化 DMG，并通过 `arch` 为 Apple Silicon/Intel 
 
 ### 7.3 WinGet
 
-使用现有 Windows x64 NSIS 安装器，首期 PackageIdentifier 建议为 `estelwalks.AITracker`，最终 Publisher 字段必须与 Windows“应用和功能”中安装器写入的 Publisher 完全一致。
+使用现有 Windows x64/arm64 NSIS 安装器，首期 PackageIdentifier 建议为 `estelwalks.AITracker`，最终 Publisher 字段必须与 Windows“应用和功能”中安装器写入的 Publisher 完全一致。
 
 生成三文件 manifest：version、installer、defaultLocale。关键字段包括：
 
-- `Architecture: x64`
+- `Architecture: x64`、`Architecture: arm64`
 - `InstallerType: nullsoft`
 - `Scope: machine`（与当前 Electron Builder `perMachine: true` 一致）
 - 版本化 `InstallerUrl` 和 `InstallerSha256`

--- a/docs/plan/aitracker-敏捷任务清单.md
+++ b/docs/plan/aitracker-敏捷任务清单.md
@@ -28,11 +28,11 @@
 
 **目标用户：** Node.js 开发者、macOS Homebrew 用户、Windows WinGet 用户、AITracker 发布维护者。
 
-**范围：** macOS arm64/x64、Windows x64；稳定版和 beta 频道；GitHub Releases、npm、Homebrew Cask、WinGet Community Repository。
+**范围：** macOS arm64/x64、Windows x64/arm64；稳定版和 beta 频道；GitHub Releases、npm、Homebrew Cask、WinGet Community Repository。
 
-**不在本期：** Linux、Mac App Store/Microsoft Store、Windows ARM64、企业私有源、完全无确认的系统级静默安装、独立 CDN。
+**不在本期：** Linux、Mac App Store/Microsoft Store、企业私有源、完全无确认的系统级静默安装、独立 CDN。
 
-**当前交付边界：** 本轮只实现未签名 beta 的 npx CLI 和自有 Homebrew Tap 的本地生成/安装入口。GitHub Actions 已准备未签名 beta 的版本门禁、三平台构建、metadata/checksum 生成和 draft Release；npm 真实发布、远程 Tap 同步、稳定版签名、官方 Cask、WinGet 以及真实平台安装冒烟均未完成。
+**当前交付边界：** 本轮只实现未签名 beta 的 npx CLI 和自有 Homebrew Tap 的本地生成/安装入口。GitHub Actions 已准备未签名 beta 的版本门禁、四平台构建（含在 x64 runner 上交叉构建的 Windows arm64）、metadata/checksum 生成和 draft Release；npm 真实发布、远程 Tap 同步、稳定版签名、官方 Cask、WinGet 以及真实平台安装冒烟均未完成。
 
 ## 2. 优先级和里程碑
 
@@ -67,7 +67,7 @@ Story 开始前必须具备：
 **验收标准：**
 
 - `package.json` 版本、Git tag、制品文件名和 metadata 版本不一致时 CI 失败。
-- metadata 覆盖 darwin-arm64、darwin-x64、win32-x64，含不可变 URL、SHA-256 和大小。
+- metadata 覆盖 darwin-arm64、darwin-x64、win32-x64、win32-arm64，含不可变 URL、SHA-256 和大小。
 - 对缺失制品、重复平台、非法 host、非法 hash 有单元测试。
 
 #### Tasks
@@ -92,9 +92,10 @@ Story 开始前必须具备：
 #### Tasks
 
 - [ ] T-0021：重构 macOS 构建为 CI 可执行的 x64/arm64 矩阵并接入签名、公证 — macOS 发布 — 1.5 人日
-- [ ] T-0022：重构 Windows x64 NSIS 构建并接入 Authenticode 签名 — Windows 发布 — 1.5 人日
+- [ ] T-0022：重构 Windows x64/arm64 NSIS 构建并接入 Authenticode 签名 — Windows 发布 — 1.5 人日
 - [x] T-0023：新增未签名 beta draft Release 上传、metadata 汇总和门禁 — DevOps — 1 人日
 - [ ] T-0024：按频道在干净 runner 验证签名（稳定版）或安全提示（beta）、安装、首次启动和卸载 — QA/DevOps — 1 人日
+- [x] T-0025：新增 Windows arm64 NSIS 目标、release metadata/schema 第四平台、CLI 平台选择和 CI 矩阵项 — Windows 发布 — 0.5 人日
 
 ### Story S-101：创建独立 npx 安装器 CLI
 
@@ -106,7 +107,7 @@ Story 开始前必须具备：
 **验收标准：**
 
 - 根 Electron 包继续保持 private；公开 npm 包只有 CLI 运行所需文件。
-- macOS arm64/x64 和 Windows x64 可正确选择同版本制品。
+- macOS arm64/x64 和 Windows x64/arm64 可正确选择同版本制品。
 - checksum、host、大小或平台检查失败时返回非零状态且不启动安装器。
 - 第一阶段未签名 beta 可以继续进入安装器，但 CLI 和 README 必须明确可能出现的 macOS Gatekeeper/Windows 安全提示。
 - 支持 stable、beta、精确 npm 版本、`--dry-run` 和 `--download-only`。

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -56,13 +56,37 @@ win:
     - target: nsis
       arch:
         - x64
+        # Windows on ARM. Cross-built from an x64 host: the app payload is the
+        # native win32-arm64 Electron build, while the NSIS installer stub
+        # itself stays x86 and runs under Windows' x86 emulation (the bundled
+        # NSIS 3.0.4.1 emits no ARM64 stub; its templates pick app-64 or
+        # app-arm64 at install time via ${IsNativeARM64}).
+        #
+        # These entries only apply when no target/arch is named on the command
+        # line. `npm run dist:win` (bare `--win`) then emits a combined
+        # AITracker-Setup-<version>.exe carrying both payloads plus one
+        # installer per architecture, while `npm run dist:win:x64` and
+        # `npm run dist:win:arm64` pass an explicit arch (which overrides this
+        # list) and emit exactly one installer each — that is what the release
+        # workflow builds.
+        - arm64
   # Keep the EXE and pinned shortcut transparent, like the running window.
   # The three light trails remain part of the artwork at every icon size.
   icon: build/native-icons/icon.ico
 nsis:
   artifactName: "${productName}-Setup-${version}-${arch}.${ext}"
   oneClick: false
-  # Install for all users; the NSIS default becomes C:\Program Files\AITracker.
+  # Install for all users. Note the default directory, which comes from
+  # electron-builder's multiUser.nsh: it only promotes $PROGRAMFILES to
+  # $PROGRAMFILES64 inside `!ifdef APP_64`, and a 32-bit NSIS process resolves
+  # $PROGRAMFILES to the x86 view (verified with a probe built by the bundled
+  # makensis: $PROGRAMFILES=C:\Program Files (x86),
+  # $PROGRAMFILES64=C:\Program Files). So the x64 installer lands in
+  # C:\Program Files\AITracker, while the arm64-only installer — which defines
+  # APP_ARM64 but not APP_64 — lands in C:\Program Files (x86)\AITracker.
+  # The "Apps & features" entry is unaffected either way (check64BitAndSetRegView
+  # sets the 64-bit registry view for APP_ARM64), and users can still choose a
+  # directory because allowToChangeInstallationDirectory is enabled.
   perMachine: true
   allowToChangeInstallationDirectory: true
   createDesktopShortcut: true

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "dist:mac:arm64": "npm run build:desktop && electron-builder --mac dmg --arm64 --publish never",
     "dist:win": "npm run build:desktop && electron-builder --win",
     "dist:win:x64": "npm run build:desktop && electron-builder --win nsis --x64 --publish never",
+    "dist:win:arm64": "npm run build:desktop && electron-builder --win nsis --arm64 --publish never",
     "packaging:cli": "npm pack --dry-run ./packages/cli",
     "verify:release-contract": "node scripts/verify-release-contract.mjs",
     "release:metadata": "node scripts/release-metadata.mjs",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -14,7 +14,7 @@ npx @estelwalks/aitracker --download-only ./downloads # save verified installer 
 npx @estelwalks/aitracker --download-only=./downloads # equivalent directory form
 ```
 
-The CLI supports macOS arm64/x64 and Windows x64. Linux and unsupported
+The CLI supports macOS arm64/x64 and Windows x64/arm64. Linux and unsupported
 architectures are rejected; the installer is selected from the public GitHub
 Release metadata, streamed with a 30-minute total timeout and a two-minute
 no-progress timeout, and verified with its SHA-256 and byte size before it is

--- a/packages/cli/src/release-metadata.mjs
+++ b/packages/cli/src/release-metadata.mjs
@@ -10,6 +10,7 @@ const RELEASE_REDIRECT_HOSTS = new Set([
 export const SUPPORTED_PLATFORMS = Object.freeze([
   "darwin-arm64",
   "darwin-x64",
+  "win32-arm64",
   "win32-x64",
 ]);
 
@@ -47,7 +48,7 @@ export function platformKey(platform, arch) {
   if (!SUPPORTED_PLATFORMS.includes(key)) {
     throw new Error(
       `Unsupported platform/architecture: ${platform}/${arch}. ` +
-        "Supported targets are macOS arm64, macOS x64, and Windows x64.",
+        "Supported targets are macOS arm64, macOS x64, Windows x64, and Windows arm64.",
     );
   }
   return key;
@@ -138,7 +139,7 @@ function assertArtifact(artifact, key, appVersion) {
       throw new Error(`${prefix} has unknown field: ${field}`);
     }
   }
-  const expectedExtension = key === "win32-x64" ? ".exe" : ".dmg";
+  const expectedExtension = key.startsWith("win32-") ? ".exe" : ".dmg";
   if (
     typeof artifact.name !== "string" ||
     artifact.name.length === 0 ||

--- a/packages/cli/test/cli.test.mjs
+++ b/packages/cli/test/cli.test.mjs
@@ -40,6 +40,15 @@ const metadata = {
       sha256,
       size: bytes.length,
     },
+    "win32-arm64": {
+      name: "AITracker-Setup-1.0.0-beta.3-arm64.exe",
+      url: artifactUrl.replace(
+        "AITracker-1.0.0-beta.3-arm64.dmg",
+        "AITracker-Setup-1.0.0-beta.3-arm64.exe",
+      ),
+      sha256,
+      size: bytes.length,
+    },
     "win32-x64": {
       name: "AITracker-Setup-1.0.0-beta.3-x64.exe",
       url: artifactUrl.replace(
@@ -286,6 +295,21 @@ test("rejects malicious final response hosts while allowing GitHub release asset
         },
       }),
     /must resolve to github\.com, release-assets\.githubusercontent\.com, or objects\.githubusercontent\.com/,
+  );
+});
+
+test("selects the Windows arm64 installer for win32/arm64", async () => {
+  const { fetchImpl } = fakeFetch();
+  const resolved = await resolveRelease({
+    channel: "beta",
+    version: "1.0.0-beta.3",
+    platform: "win32",
+    arch: "arm64",
+    fetchImpl,
+  });
+  assert.equal(
+    resolved.artifact.name,
+    "AITracker-Setup-1.0.0-beta.3-arm64.exe",
   );
 });
 

--- a/packages/cli/test/release-metadata.test.mjs
+++ b/packages/cli/test/release-metadata.test.mjs
@@ -26,10 +26,15 @@ function validMetadata() {
     artifacts: {
       "darwin-arm64": artifact("darwin-arm64", 1),
       "darwin-x64": artifact("darwin-x64", 2),
-      "win32-x64": {
-        ...artifact("win32-x64", 3),
+      "win32-arm64": {
+        ...artifact("win32-arm64", 3),
         name: "file-3.exe",
         url: goodUrl.replace("file.dmg", "file-3.exe"),
+      },
+      "win32-x64": {
+        ...artifact("win32-x64", 4),
+        name: "file-4.exe",
+        url: goodUrl.replace("file.dmg", "file-4.exe"),
       },
     },
   };
@@ -39,6 +44,11 @@ test("validates the shared metadata contract and selects a platform", () => {
   const metadata = validateReleaseMetadata(validMetadata());
   assert.equal(findArtifact(metadata, "darwin", "arm64").name, "file-1.dmg");
   assert.equal(platformKey("win32", "x64"), "win32-x64");
+  assert.equal(
+    findArtifact(metadata, "win32", "arm64").name,
+    "file-3.exe",
+    "Windows on ARM resolves to the arm64 NSIS installer",
+  );
 });
 
 test("rejects duplicate/missing platforms, invalid versions, hashes, sizes and channels", () => {
@@ -109,6 +119,9 @@ test("rejects unsafe artifact names and platform-mismatched extensions", () => {
     },
     (value) => {
       value.artifacts["win32-x64"].name = "installer.dmg";
+    },
+    (value) => {
+      value.artifacts["win32-arm64"].name = "installer.dmg";
     },
   ]) {
     const invalid = validMetadata();

--- a/schemas/release-metadata.schema.json
+++ b/schemas/release-metadata.schema.json
@@ -35,10 +35,11 @@
     "artifacts": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["darwin-arm64", "darwin-x64", "win32-x64"],
+      "required": ["darwin-arm64", "darwin-x64", "win32-arm64", "win32-x64"],
       "properties": {
         "darwin-arm64": { "$ref": "#/$defs/artifact" },
         "darwin-x64": { "$ref": "#/$defs/artifact" },
+        "win32-arm64": { "$ref": "#/$defs/artifact" },
         "win32-x64": { "$ref": "#/$defs/artifact" }
       }
     }

--- a/scripts/generate-homebrew-cask.test.mjs
+++ b/scripts/generate-homebrew-cask.test.mjs
@@ -40,6 +40,12 @@ function fixture(channel = "stable") {
         sha256: INTEL_SHA,
         size: 123457,
       },
+      "win32-arm64": {
+        name: `AITracker-Setup-${version}-arm64.exe`,
+        url: `https://github.com/estelwalks/aitracker/releases/download/v${version}/AITracker-Setup-${version}-arm64.exe`,
+        sha256: "d".repeat(64),
+        size: 123459,
+      },
       "win32-x64": {
         name: `AITracker-Setup-${version}-x64.exe`,
         url: `https://github.com/estelwalks/aitracker/releases/download/v${version}/AITracker-Setup-${version}-x64.exe`,

--- a/scripts/release-metadata.mjs
+++ b/scripts/release-metadata.mjs
@@ -3,6 +3,7 @@
 import { createHash } from "node:crypto";
 import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   assertAllowedDownloadUrl,
   assertValidChannel,
@@ -15,6 +16,7 @@ import {
 const TARGET_FILES = Object.freeze([
   ["darwin-arm64", (version) => `AITracker-${version}-arm64.dmg`],
   ["darwin-x64", (version) => `AITracker-${version}-x64.dmg`],
+  ["win32-arm64", (version) => `AITracker-Setup-${version}-arm64.exe`],
   ["win32-x64", (version) => `AITracker-Setup-${version}-x64.exe`],
 ]);
 
@@ -128,7 +130,14 @@ export async function generateReleaseMetadata(options) {
   return metadata;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Path comparison instead of `file://${process.argv[1]}`: on Windows
+// import.meta.url is `file:///D:/...` while the naive interpolation produces
+// `file://D:\...`, so the entry block would never run and the CLI would exit 0
+// without generating anything.
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))
+) {
   try {
     const options = parseReleaseMetadataArgs(process.argv.slice(2));
     await generateReleaseMetadata(options);

--- a/scripts/release-metadata.test.mjs
+++ b/scripts/release-metadata.test.mjs
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 import {
   buildReleaseMetadata,
   formatChecksums,
@@ -11,9 +13,15 @@ import {
   parseReleaseMetadataArgs,
 } from "./release-metadata.mjs";
 
+const SCRIPT = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "release-metadata.mjs",
+);
+
 const files = [
   "AITracker-1.0.0-beta.1-arm64.dmg",
   "AITracker-1.0.0-beta.1-x64.dmg",
+  "AITracker-Setup-1.0.0-beta.1-arm64.exe",
   "AITracker-Setup-1.0.0-beta.1-x64.exe",
 ];
 
@@ -24,6 +32,15 @@ async function fixtureDirectory() {
   }
   return directory;
 }
+
+test("the CLI entry point actually runs when invoked as a script", () => {
+  // Same Windows regression as verify-release-contract.mjs: the naive
+  // `file://${process.argv[1]}` entry check never matched, so the script
+  // exited 0 without generating metadata or checksums.
+  const result = spawnSync(process.execPath, [SCRIPT], { encoding: "utf8" });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /--version is required/);
+});
 
 test("builds metadata and checksums using electron-builder names", async () => {
   const directory = await fixtureDirectory();
@@ -42,7 +59,8 @@ test("builds metadata and checksums using electron-builder names", async () => {
       [
         { platform: "darwin-arm64", name: files[0], size: 10 },
         { platform: "darwin-x64", name: files[1], size: 10 },
-        { platform: "win32-x64", name: files[2], size: 10 },
+        { platform: "win32-arm64", name: files[2], size: 10 },
+        { platform: "win32-x64", name: files[3], size: 10 },
       ],
     );
     for (const [index, artifact] of Object.values(
@@ -85,7 +103,7 @@ test("writes independently selectable metadata and checksum outputs", async () =
       (
         await readFile(join(outputDirectory, "nested", "checksums.txt"), "utf8")
       ).split("\n").length,
-      4,
+      5,
     );
   } finally {
     await rm(directory, { recursive: true, force: true });

--- a/scripts/verify-release-contract.mjs
+++ b/scripts/verify-release-contract.mjs
@@ -34,6 +34,7 @@ export const ERROR_CODES = Object.freeze({
 export const RELEASE_PLATFORMS = Object.freeze([
   "darwin-arm64",
   "darwin-x64",
+  "win32-arm64",
   "win32-x64",
 ]);
 
@@ -122,6 +123,10 @@ export function expectedReleaseArtifacts(version, platform) {
     Object.freeze({
       platform: "darwin-x64",
       name: `AITracker-${version}-x64.dmg`,
+    }),
+    Object.freeze({
+      platform: "win32-arm64",
+      name: `AITracker-Setup-${version}-arm64.exe`,
     }),
     Object.freeze({
       platform: "win32-x64",
@@ -290,7 +295,14 @@ function printSuccess(contract) {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Path comparison instead of `file://${process.argv[1]}`: on Windows
+// import.meta.url is `file:///D:/...` while the naive interpolation produces
+// `file://D:\...`, so the CLI gate in the Windows release job would exit 0
+// without verifying anything.
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))
+) {
   try {
     const options = parseReleaseContractArgs(process.argv.slice(2));
     printSuccess(await verifyReleaseContract(options));

--- a/scripts/verify-release-contract.test.mjs
+++ b/scripts/verify-release-contract.test.mjs
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 import {
   ERROR_CODES,
   EXIT_CODES,
@@ -12,6 +14,11 @@ import {
   validateReleaseContract,
   verifyReleaseContract,
 } from "./verify-release-contract.mjs";
+
+const SCRIPT = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "verify-release-contract.mjs",
+);
 
 const betaPackages = {
   rootPackage: { version: "1.0.0-beta.1" },
@@ -28,6 +35,10 @@ test("accepts matching strict-semver packages and derives beta contract", () => 
     [
       { platform: "darwin-arm64", name: "AITracker-1.0.0-beta.1-arm64.dmg" },
       { platform: "darwin-x64", name: "AITracker-1.0.0-beta.1-x64.dmg" },
+      {
+        platform: "win32-arm64",
+        name: "AITracker-Setup-1.0.0-beta.1-arm64.exe",
+      },
       {
         platform: "win32-x64",
         name: "AITracker-Setup-1.0.0-beta.1-x64.exe",
@@ -169,7 +180,21 @@ test("checks only the matrix platform when requested, while aggregate checks rem
   }
 });
 
-test("checks all three artifacts only when release-dir is explicitly supplied", async () => {
+test("the CLI entry point actually runs when invoked as a script", () => {
+  // Guards against the Windows-only regression where the entry check compared
+  // import.meta.url against `file://${process.argv[1]}` and therefore never
+  // matched, making every `npm run verify:release-contract` invocation exit 0
+  // without checking anything.
+  const result = spawnSync(
+    process.execPath,
+    [SCRIPT, "--platform", "linux-x64"],
+    { encoding: "utf8" },
+  );
+  assert.equal(result.status, EXIT_CODES.usage);
+  assert.match(result.stderr, /RC_PLATFORM_INVALID/);
+});
+
+test("checks all four artifacts only when release-dir is explicitly supplied", async () => {
   const rootDir = await mkdtemp(join(tmpdir(), "aitracker-contract-test-"));
   const releaseDir = join(rootDir, "release");
   try {
@@ -184,7 +209,7 @@ test("checks all three artifacts only when release-dir is explicitly supplied", 
     );
 
     const withoutDirectory = await verifyReleaseContract({ rootDir });
-    assert.equal(withoutDirectory.artifacts.length, 3);
+    assert.equal(withoutDirectory.artifacts.length, 4);
     await assert.rejects(
       () => verifyReleaseContract({ rootDir, releaseDir, cwd: rootDir }),
       (error) => error.errorCode === ERROR_CODES.artifactDirectory,


### PR DESCRIPTION
Add Windows on ARM as a fourth release target. It is cross-built on the x64 runner, so no ARM64 runner is required: NSIS embeds the native win32-arm64 Electron payload while the installer stub itself stays x86 and runs under Windows' x86 emulation.

- electron-builder.yml: add arm64 to win.target.arch, documenting the emulated stub and the default install directory it implies for the arm64 package.
- package.json: add dist:win:arm64.
- Release contract: add win32-arm64 to RELEASE_PLATFORMS, expectedReleaseArtifacts, the metadata TARGET_FILES, the metadata JSON schema, and the CLI platform table, so the npx launcher resolves Windows on ARM to its own installer instead of falling back to the x64 one.
- release.yml: add the Windows arm64 matrix job on windows-latest, and update the draft-release assembly and release notes.
- Fix the CLI entry guard in verify-release-contract.mjs and release-metadata.mjs: comparing import.meta.url against `file://${process.argv[1]}` never matches on Windows (import.meta.url is file:///D:/...), so both gates exited 0 without checking anything and the two Windows steps in the release workflow were silent no-ops. Covered by new process-level regression tests.
- Docs: README (four locales), DEVELOPMENT, RELEASE_CHECKLIST, the design and plan documents, the CLI README, and CHANGELOG. Also correct the release download links, which still named 1.0.0 assets under the v1.0.1 tag.

## Summary

Describe the problem and the change.

## Validation

- [ ] Tests added or updated where appropriate
- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm run test:all`
- [ ] `npm run build:desktop`

## Privacy and compatibility

Describe any local-data, security, migration, packaging, or platform impact.
